### PR TITLE
Fix code block reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Create a .env file, with the following properties:
 
 The app is built with TypeScript. Use `npm run` to see build targets.
 
-To change the rivers that are checked, change the station IDs in `src/FloodSkeet.ts.`
+To change the rivers that are checked, change the station IDs in `src/FloodSkeet.ts`.
 
 You can find ids via the website at http://www.environment-agency.gov.uk/homeandleisure/floods/riverlevels/.
 


### PR DESCRIPTION
## Summary
- fix trailing period in station instructions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684052184b4c832da175f8b41cd86705