### PR TITLE
Add AGENTS setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# Environment Setup
+
+To run the automated tests, install the Node dependencies and Jest.
+
+```bash
+# Install dependencies (includes Jest)
+npm ci
+
+# Optionally ensure the Jest CLI is available
+npm install -g jest
+```
+
+## Running Tests
+
+```bash
+npm test
+```


### PR DESCRIPTION
## Summary
- provide setup instructions in AGENTS.md so agents can install Jest and other dependencies before running tests

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684053b84ac4832daa677b8934d058ca