### PR TITLE
Add Bluesky posting tests

### DIFF
--- a/src/Bluesky.test.ts
+++ b/src/Bluesky.test.ts
@@ -1,0 +1,66 @@
+const postMock = jest.fn();
+const loginMock = jest.fn();
+
+
+describe('Bluesky.post', () => {
+  const createBluesky = () => {
+    let Cls!: typeof import('./Bluesky').Bluesky;
+    jest.isolateModules(() => {
+      jest.doMock('@atproto/api', () => ({
+        Agent: class { post = postMock; },
+        CredentialSession: class { login = loginMock; constructor() {} },
+      }));
+      Cls = require('./Bluesky').Bluesky;
+    });
+    return new Cls('user', 'pass');
+  };
+
+  beforeEach(() => {
+    postMock.mockReset();
+    loginMock.mockReset();
+  });
+
+  it('sends link facet when URL provided and awaits post', async () => {
+    let resolvePost: () => void;
+    const postPromise = new Promise<void>(res => { resolvePost = res; });
+    postMock.mockReturnValue(postPromise);
+    loginMock.mockResolvedValue(undefined);
+
+    const bluesky = createBluesky();
+    const promise = bluesky.post('hello [world]', 'https://example.com');
+
+    await Promise.resolve();
+
+    expect(postMock).toHaveBeenCalledWith({
+      text: 'hello world',
+      facets: [
+        {
+          index: { byteStart: 6, byteEnd: 11 },
+          features: [{ $type: 'app.bsky.richtext.facet#link', uri: 'https://example.com' }]
+        }
+      ]
+    });
+
+    let finished = false;
+    promise.then(() => { finished = true; });
+    await Promise.resolve();
+    expect(finished).toBe(false);
+
+    resolvePost!();
+    await promise;
+    expect(finished).toBe(true);
+  });
+
+  it('omits facets when URL missing', async () => {
+    postMock.mockResolvedValue(undefined);
+    loginMock.mockResolvedValue(undefined);
+
+    const bluesky = createBluesky();
+    await bluesky.post('hello [world]');
+
+    expect(postMock).toHaveBeenCalledWith({
+      text: 'hello world',
+      facets: []
+    });
+  });
+});

--- a/src/Bluesky.test.ts
+++ b/src/Bluesky.test.ts
@@ -1,19 +1,15 @@
 const postMock = jest.fn();
 const loginMock = jest.fn();
 
+jest.mock('@atproto/api', () => ({
+  Agent: class { post = postMock },
+  CredentialSession: class { login = loginMock },
+}));
+
+import { Bluesky } from './Bluesky';
 
 describe('Bluesky.post', () => {
-  const createBluesky = () => {
-    let Cls!: typeof import('./Bluesky').Bluesky;
-    jest.isolateModules(() => {
-      jest.doMock('@atproto/api', () => ({
-        Agent: class { post = postMock; },
-        CredentialSession: class { login = loginMock; constructor() {} },
-      }));
-      Cls = require('./Bluesky').Bluesky;
-    });
-    return new Cls('user', 'pass');
-  };
+  const createBluesky = () => new Bluesky('user', 'pass');
 
   beforeEach(() => {
     postMock.mockReset();

--- a/src/Bluesky.ts
+++ b/src/Bluesky.ts
@@ -26,7 +26,7 @@ export class Bluesky {
       }
     ] : [];
 
-    agent.post(
+    await agent.post(
       {
         text: messageWithoutBraces,
         facets: facets


### PR DESCRIPTION
## Summary
- ensure Bluesky awaits Agent.post before returning
- add unit tests for Bluesky.post

## Testing
- `npm test --silent`
- `npm ci`
- `npm install -g jest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68405a62f650832dbcc0fe0d660b037b