### PR TITLE
Rename describe block to getStationData

### DIFF
--- a/src/LevelDownloader.test.ts
+++ b/src/LevelDownloader.test.ts
@@ -170,7 +170,7 @@ describe('LevelDownloader', () => {
   });
 
 
-  describe('getWaterLevels', () => {
+  describe('getStationData', () => {
     beforeEach(() => {
       global.fetch = jest.fn();
     });


### PR DESCRIPTION
## Summary
- fix the describe name for testing `getStationData`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68406c77251c832d8eaee5ef74d6cc36